### PR TITLE
Fixing participants count only working on last project.

### DIFF
--- a/src/pycamp_bot/commands/projects.py
+++ b/src/pycamp_bot/commands/projects.py
@@ -197,9 +197,9 @@ def show_projects(bot, update):
             project.difficult_level
         )
         text.append(project_text)
-    participants_count = Vote.select().where(Vote.project == project).count()
-    if participants_count > 0:
-        project_text += "\n Interesades: {}".format(participants_count)
+        participants_count = Vote.select().where(Vote.project == project).count()
+        if participants_count > 0:
+            project_text += "\n Interesades: {}".format(participants_count)
     text.append(project_text)
 
     if text:


### PR DESCRIPTION
There was an indentation error that only added the vote count to the last project.