### PR TITLE
add unrecognised command handler. add @ to admin list

### DIFF
--- a/bin/run_bot.py
+++ b/bin/run_bot.py
@@ -1,5 +1,5 @@
 import os
-from telegram.ext import Application
+from telegram.ext import Application, MessageHandler, filters
 from pycamp_bot.commands import auth
 from pycamp_bot.commands import voting
 from pycamp_bot.commands import manage_pycamp
@@ -12,6 +12,10 @@ from pycamp_bot.commands import announcements
 from pycamp_bot.models import models_db_connection
 from pycamp_bot.logger import logger
 
+async def unknown_command(update, context):
+    text = "No reconozco el comando, para ver comandos válidos usá /ayuda"
+    await context.bot.send_message(chat_id=update.message.chat_id, text=text)
+
 
 def set_handlers(application):
     base.set_handlers(application)
@@ -23,6 +27,7 @@ def set_handlers(application):
     raffle.set_handlers(application)
     schedule.set_handlers(application)
     announcements.set_handlers(application)
+    application.add_handler(MessageHandler(filters.COMMAND, unknown_command))
 
 
 if __name__ == '__main__':

--- a/src/pycamp_bot/commands/auth.py
+++ b/src/pycamp_bot/commands/auth.py
@@ -86,18 +86,17 @@ async def revoke_admin(update, context):
     user.admin = False
     user.save()
     await context.bot.send_message(chat_id=chat_id,
-                     text='Un admin a caido --{}--.'.format(fallen_admin))
+                     text='Un admin ha caido --{}--.'.format(fallen_admin))
 
 
 async def list_admins(update, context):
     chat_id = update.message.chat_id
 
     admins = get_admins_username()
-    rply_msg = 'Los administradores son:\n'
+    rply_msg = 'Lxs administradorxs son:\n'
 
     for admin in admins:
-        rply_msg += admin
-        rply_msg += '\n'
+        rply_msg += '@' + admin + '\n'
 
     await context.bot.send_message(chat_id=chat_id, text=rply_msg)
 

--- a/src/pycamp_bot/commands/base.py
+++ b/src/pycamp_bot/commands/base.py
@@ -45,3 +45,4 @@ def set_handlers(application):
 
     application.add_handler(CommandHandler('start', start))
     application.add_handler(CommandHandler('ayuda', help))
+    application.add_handler(CommandHandler('help', help))


### PR DESCRIPTION
closes https://github.com/PyAr/PyCamp_Bot/issues/13

- Agrega el handler para manejar mensajes que empiecen con / que no matcheen comandos válidos.
- Agregué un @ adelante de los nombres de admines en el print de la lista a pedido de @WinnaZ 