### PR TITLE
Add mis_proyectos command

### DIFF
--- a/src/pycamp_bot/commands/help_msg.py
+++ b/src/pycamp_bot/commands/help_msg.py
@@ -7,6 +7,7 @@ Comandos de usuario:
 /pycamps: lista todos los pycamps.
 /cargar_proyecto: empieza la conversacion de carga de proyecto.
 /proyectos: te muestra la informacion de todos los proyectos y sus responsables.
+/mis_proyectos: te muestra día y horario de los proyectos que votaste.
 /ser_magx: te agrega la lista de Magx.
 /evocar_magx: pingea a la/el Magx de turno, informando que necesitas su\
     ayuda. Con un gran poder, viene una gran responsabilidad.

--- a/src/pycamp_bot/commands/projects.py
+++ b/src/pycamp_bot/commands/projects.py
@@ -1,10 +1,11 @@
 import logging
 import peewee
 from telegram.ext import ConversationHandler, CommandHandler, MessageHandler, filters
-from pycamp_bot.models import Pycampista, Project, Vote
+from pycamp_bot.models import Pycampista, Project, Slot, Vote
 from pycamp_bot.commands.base import msg_to_active_pycamp_chat
 from pycamp_bot.commands.manage_pycamp import active_needed, get_active_pycamp
 from pycamp_bot.commands.auth import admin_needed, get_admins_username
+from pycamp_bot.commands.schedule import DIAS
 
 
 current_projects = {}
@@ -254,6 +255,41 @@ async def show_projects(update, context):
     await update.message.reply_text(text)
 
 
+async def show_my_projects(update, context):
+    """Let people see what projects they have voted for"""
+
+    user_id = Pycampista.get(Pycampista.username == update.message.from_user.username)
+    votes = Vote.select(Project, Slot).join(Project).join(Slot).where((Vote.pycampista == user_id) & Vote.interest).order_by(Slot.code)
+
+    if votes:
+        text_chunks = []
+
+        prev_slot_day_code = None
+
+        for vote in votes:
+            slot_day_code = vote.project.slot.code[0]
+            slot_day_name = DIAS[slot_day_code]
+
+            if slot_day_code != prev_slot_day_code:
+                text_chunks.append(f'*{slot_day_name}*')
+
+            slot_start_time = str(vote.project.slot.start) + ':00'
+            project_text = "{}\n{}\nOwner: @{}".format(
+                slot_start_time,
+                vote.project.name,
+                vote.project.owner.username,
+            )
+            text_chunks.append(project_text)
+
+            prev_slot_day_code = slot_day_code
+
+        text = '\n\n'.join(text_chunks)
+    else:
+        text = "No votaste por ningún proyecto"
+
+    await update.message.reply_text(text, parse_mode='Markdown')
+
+
 def set_handlers(application):
     application.add_handler(load_project_handler)
     application.add_handler(
@@ -264,3 +300,6 @@ def set_handlers(application):
         CommandHandler('borrar_proyecto', delete_project))
     application.add_handler(
         CommandHandler('proyectos', show_projects))
+    application.add_handler(
+        CommandHandler('mis_proyectos', show_my_projects))
+

--- a/src/pycamp_bot/commands/projects.py
+++ b/src/pycamp_bot/commands/projects.py
@@ -258,8 +258,8 @@ async def show_projects(update, context):
 async def show_my_projects(update, context):
     """Let people see what projects they have voted for"""
 
-    user_id = Pycampista.get(Pycampista.username == update.message.from_user.username)
-    votes = Vote.select(Project, Slot).join(Project).join(Slot).where((Vote.pycampista == user_id) & Vote.interest).order_by(Slot.code)
+    user = Pycampista.get(Pycampista.username == update.message.from_user.username)
+    votes = Vote.select(Project, Slot).join(Project).join(Slot).where((Vote.pycampista == user) & Vote.interest).order_by(Slot.code)
 
     if votes:
         text_chunks = []
@@ -273,13 +273,13 @@ async def show_my_projects(update, context):
             if slot_day_code != prev_slot_day_code:
                 text_chunks.append(f'*{slot_day_name}*')
 
-            slot_start_time = str(vote.project.slot.start) + ':00'
-            project_text = "{}\n{}\nOwner: @{}".format(
-                slot_start_time,
+            project_lines = [
+                f'{vote.project.slot.start}:00',
                 vote.project.name,
-                vote.project.owner.username,
-            )
-            text_chunks.append(project_text)
+                f'Owner: @{vote.project.owner.username}',
+            ]
+
+            text_chunks.append('\n'.join(project_lines))
 
             prev_slot_day_code = slot_day_code
 

--- a/src/pycamp_bot/commands/projects.py
+++ b/src/pycamp_bot/commands/projects.py
@@ -258,8 +258,20 @@ async def show_projects(update, context):
 async def show_my_projects(update, context):
     """Let people see what projects they have voted for"""
 
-    user = Pycampista.get(Pycampista.username == update.message.from_user.username)
-    votes = Vote.select(Project, Slot).join(Project).join(Slot).where((Vote.pycampista == user) & Vote.interest).order_by(Slot.code)
+    user = Pycampista.get(
+        Pycampista.username == update.message.from_user.username,
+    )
+    votes = (
+        Vote
+        .select(Project, Slot)
+        .join(Project)
+        .join(Slot)
+        .where(
+            (Vote.pycampista == user) &
+            Vote.interest
+        )
+        .order_by(Slot.code)
+    )
 
     if votes:
         text_chunks = []


### PR DESCRIPTION
Command is used to see the presentation times of the projects one has voted for.

Example output:

```
Jueves

15:00
bot del pycamp
Owner: @WinnaZ

16:00
generar pasos para el pump it up
Owner: @WinnaZ

17:00
coding dojo
Owner: @WinnaZ

Viernes

9:00
retro-python
Owner: @hugoruscitti

16:00
show and tell configs, entornos, editores, plugins
Owner: @fisadev
```