### PR TITLE
Fix empezar_proyecto workflow

### DIFF
--- a/src/pycamp_bot/commands/manage_pycamp.py
+++ b/src/pycamp_bot/commands/manage_pycamp.py
@@ -152,6 +152,7 @@ async def define_duration(update, context):
         chat_id=update.message.chat_id,
         text=msg
     )
+    return ConversationHandler.END
 
 
 async def cancel(update, context):


### PR DESCRIPTION
Fixes:

```
> /empezar_pycamp baradero2025

El Pycamp baradero2025 fue creado.
¿Cuándo empieza? (formato yyyy-mm-dd)

> 2025-02-20

¿Cuantos días dura el PyCamp?

> 5

Listo, el PyCamp 'baradero2025' está activo, desde el 2025-02-20 hasta el 2025-02-24

> /empezar_carga_proyectos

mmm no entiendo. Poné un número entero porfa.
```