### PR TITLE
Remove references to agregar_pycamp

### DIFF
--- a/docs/source/comandos_bot.rst
+++ b/docs/source/comandos_bot.rst
@@ -9,7 +9,6 @@ Comandos de Administrador
 -------------------------
 
 - ``/su <password>``: Reclama permisos de admin, la contraseña es la usada en la variable de entorno ``PYCAMP_BOT_MASTER_KEY``.
-- ``/agregar_pycamp <pycamp_name>``: Crea el PyCamp en la DB.
 - ``/activar_pycamp <pycamp_name>``: Activa un Pycamp.
 - ``/empezar_pycamp``: Setea la fecha de inicio del pycamp activo.
 - ``/empezar_carga_proyectos``: Habilita la carga de los proyectos. En este punto los pycampistas pueden cargar sus proyectos, enviandole al bot el comando ``/cargar_proyecto``.

--- a/src/pycamp_bot/commands/help_msg.py
+++ b/src/pycamp_bot/commands/help_msg.py
@@ -49,7 +49,6 @@ HELP_MESSAGE_ADMIN = '''
 Be AWARE, you have sudo\\.\\.\\.
 
 Pycamp:
-/agregar\\_pycamp \\(pycamp\\): Agrega un pycamp\\.
 /activar\\_pycamp \\(pycamp\\): Setea un pycamp como activo \\(si ya hay uno activo lo \
 desactiva\\)\\.
 /empezar\\_carga\\_proyectos: Habilita la carga de proyectos en el pycamp activo\\.


### PR DESCRIPTION
The command has been deleted on: https://github.com/PyAr/PyCamp_Bot/commit/eedab0fbdeae3347e749de963f5b65f273a3f452